### PR TITLE
Adding Grafana Pyroscope support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,8 @@ require (
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.6.0 // indirect
+	github.com/grafana/pyroscope-go v1.0.4 // indirect
+	github.com/grafana/pyroscope-go/godeltaprof v0.1.5 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-plugin v1.4.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -293,6 +293,10 @@ github.com/googleapis/gax-go/v2 v2.6.0/go.mod h1:1mjbznJAPHFpesgE5ucqfYEscaz5kMd
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/grafana/pyroscope-go v1.0.4 h1:oyQX0BOkL+iARXzHuCdIF5TQ7/sRSel1YFViMHC7Bm0=
+github.com/grafana/pyroscope-go v1.0.4/go.mod h1:0d7ftwSMBV/Awm7CCiYmHQEG8Y44Ma3YSjt+nWcWztY=
+github.com/grafana/pyroscope-go/godeltaprof v0.1.5 h1:gkFVqihFRL1Nro2FCC0u6mW47jclef96Zu8I/ykq+4E=
+github.com/grafana/pyroscope-go/godeltaprof v0.1.5/go.mod h1:1HSPtjU8vLG0jE9JrTdzjgFqdJ/VgN7fvxBNq3luJko=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/profiling/profiling.go
+++ b/profiling/profiling.go
@@ -1,0 +1,84 @@
+package profiling
+
+import (
+	"os"
+	"runtime"
+
+	"github.com/grafana/pyroscope-go"
+)
+
+type Profiler interface {
+	Start() error
+	Stop() error
+}
+
+type profiler struct {
+	prof  *pyroscope.Profiler
+	pConf pyroscope.Config
+}
+
+func NewProfiler(profilerServer, appName string, opts ...func(config *pyroscope.Config)) Profiler {
+	// These 2 lines are only required if you're using mutex or block profiling
+	// Read the explanation below for how to set these rates:
+	runtime.SetMutexProfileFraction(5)
+	runtime.SetBlockProfileRate(5)
+
+	pConf := pyroscope.Config{
+		ApplicationName: appName,
+
+		// replace this with the address of pyroscope server
+		ServerAddress: profilerServer,
+
+		// you can disable logging by setting this to nil
+		Logger: pyroscope.StandardLogger,
+
+		// you can provide static tags via a map:
+		Tags: map[string]string{"hostname": os.Getenv("HOSTNAME")},
+
+		ProfileTypes: []pyroscope.ProfileType{
+			// these profile types are enabled by default:
+			pyroscope.ProfileCPU,
+			pyroscope.ProfileAllocObjects,
+			pyroscope.ProfileAllocSpace,
+			pyroscope.ProfileInuseObjects,
+			pyroscope.ProfileInuseSpace,
+
+			// these profile types are optional:
+			pyroscope.ProfileGoroutines,
+			pyroscope.ProfileMutexCount,
+			pyroscope.ProfileMutexDuration,
+			pyroscope.ProfileBlockCount,
+			pyroscope.ProfileBlockDuration,
+		},
+	}
+
+	for _, f := range opts {
+		f(&pConf)
+	}
+
+	return &profiler{
+		pConf: pConf,
+	}
+}
+
+// Start starts the profiler
+func (p *profiler) Start() error {
+	var err error
+	p.prof, err = pyroscope.Start(p.pConf)
+
+	return err
+}
+
+// Stop stops the profiler
+func (p *profiler) Stop() error {
+	return p.prof.Stop()
+}
+
+// WithTags merges user defined tags with default tags
+func WithTags(tags map[string]string) func(config *pyroscope.Config) {
+	return func(c *pyroscope.Config) {
+		for k, v := range tags {
+			c.Tags[k] = v
+		}
+	}
+}


### PR DESCRIPTION
# Description
This PR adds the support for the `Grafana Pyroscope` profiler.    
It can be enabled in the same fashion as DataDog via environment variables.   

To enable it set these env vars:
```
PROFILER_ENABLED=true
PROFILER_SERVER=<grafana_pyroscope_server>
```

Grafana has native support for it, and it can be easily added as data source.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

